### PR TITLE
Replace external shell call with read-upto

### DIFF
--- a/gitstatus.elv
+++ b/gitstatus.elv
@@ -218,7 +218,7 @@ fn query [repository]{
 
     echo $us$repository$rs > $state[stdin]
 
-  # This depends on Elvish 0.13, which introduces read-upto
+  # This depends on Elvish commit 770904b, which introduces read-upto
     response = (read-upto $rs < $state[stdout])
 
     put (parse-response $response)


### PR DESCRIPTION
(resubmission of #4 without the incorrect statement that read-upto is included in Elvish 0.13)

Elvish now has a read-upto function, which eliminates the need to call an external Bourne shell command to read the gitstatusd response. This is not included in Elvish 0.13 but is available in master.