### PR TITLE
Use gitstatusd from PATH if it exists

### DIFF
--- a/gitstatus.elv
+++ b/gitstatus.elv
@@ -71,9 +71,14 @@ fn download {
 }
 
 # installs the gitstatusd binary and creates the necessary paths, if necessary
+# does nothing if gitstatusd is in PATH
 fn ensure-installed {
-    mkdir -p $appdir
+    if (has-external gitstatusd) {
+        # already in PATH, lets use that
+        return
+    }
 
+    mkdir -p $appdir
     if (not (has-external $binary)) {
         download
         chmod 0700 $binary
@@ -144,6 +149,11 @@ fn start {
 
     for k [stdin stdout] {
         state[$k] = (pipe)
+    }
+
+    if (has-external gitstatusd) {
+        # use from PATH
+        binary = gitstatusd
     }
 
     (external $binary) \


### PR DESCRIPTION
I use nixos and the gitstatusd built by romkatv doesnt work on it. I've packaged gitstatusd for [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix) and need elvish-gitstatus to use it instead of fetching a random binary. This is useful for people who don't want to run random binaries fetched from the internet too.