### PR TITLE
Add check for older Elvish versions

### DIFF
--- a/gitstatus.elv
+++ b/gitstatus.elv
@@ -228,8 +228,13 @@ fn query [repository]{
 
     echo $us$repository$rs > $state[stdin]
 
-    # this depends on Elvish commit 770904b, which introduces read-upto
-    response = (read-upto $rs < $state[stdout])
+    # read-upto depends on Elvish commit 770904b, otherwise fall back to calling bash
+    response = $nil
+    try {
+      response = (read-upto $rs < $state[stdout])
+    } except {
+      response = (bash -c 'read -rd $''\x1e'' && echo $REPLY' < $state[stdout])
+    }
 
     put (parse-response $response)
 }

--- a/gitstatus.elv
+++ b/gitstatus.elv
@@ -230,9 +230,10 @@ fn query [repository]{
 
     # read-upto depends on Elvish commit 770904b, otherwise fall back to calling bash
     response = $nil
-    try {
+    use builtin
+    if (has-key $builtin: read-upto~) {
       response = (read-upto $rs < $state[stdout])
-    } except {
+    } else {
       response = (bash -c 'read -rd $''\x1e'' && echo $REPLY' < $state[stdout])
     }
 


### PR DESCRIPTION
If `read-upto` does not exist, fall back to using an external bash call.

Also made the command explicitly call `bash` instead of `sh`, to avoid the issue reported in #3.